### PR TITLE
Portal "Home" view update

### DIFF
--- a/Instructions/10979F_LAB_AK_01.md
+++ b/Instructions/10979F_LAB_AK_01.md
@@ -12,7 +12,7 @@
 
 #### Task 2: Explore and customize the Azure portal interface
   
-1. Once the Azure portal loads, view the tiles on the dashboard.
+1. If the message **Choose your default view** appears across the top of the portal, select **Dashboard** and click **Save**.  Click **Dashboard** from the hub menu on the left.  View the tiles on the dashboard.
 
 1. Click the **Service Health** tile, and then, in the resulting blade, note the **Service Health - Service Issues** view. Click **Planned maintenance**, **Health advisories**, and **Resource health**. Note that you can customize each view by filtering categories of items that you are interested in, such as region, service type, or resource type.  
 


### PR DESCRIPTION
New subscribers are being prompted to choose between "Home" or "Dashboard" for their default portal view.