### PR TITLE
Template-based Docker host deployment update

### DIFF
--- a/Instructions/10979F_LAB_AK_07.md
+++ b/Instructions/10979F_LAB_AK_07.md
@@ -41,7 +41,7 @@
 1. In the Azure portal, from the Cloud Shell pane, deploy a template that will create a new Azure VM hosting Docker by typing the following and pressing Enter:
 
    ```
-   az group deployment create --resource-group 10979F0702-LabRG --template-uri https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/docker-simple-on-ubuntu/azuredeploy.json
+   az group deployment create --resource-group 10979F0702-LabRG --template-uri https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/docker-simple-on-ubuntu/azuredeploy.json --parameters authenticationType=password
    ```
 
 1. When prompted, type the following values and press Enter after each:


### PR DESCRIPTION
The docker-simple-on-ubuntu quickstart template now defaults to "sshPublicKey" for "authenticationType," causing the template-based deployment to fail unless "--parameters authenticationType=password" is added to the az cli command.